### PR TITLE
Support for JSON Schema Draft 4 required fields

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,1 +1,5 @@
-{ "presets": ["es2015"] }
+{
+  "presets": ["es2015", "stage-2"],
+  "plugins": ["transform-runtime"],
+  "comments": false
+}

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "build": "webpack",
     "e2e": "",
-    "unit": "./node_modules/mocha/bin/mocha --compilers js:babel-register --require test/unit/helper.js --recursive test/unit/specs; exit 0",
+    "unit": "./node_modules/mocha/bin/mocha --require babel-register --require babel-polyfill --require test/unit/helper.js --recursive test/unit/specs; exit 0",
     "test": "npm run mocha",
     "lint": "eslint --ext .js src; exit 0",
     "docs": "./node_modules/documentation/bin/documentation.js build -g -f html -o docs/ --name='Mutt Forms' --project-version 0.0.1 src/*.js"

--- a/src/fields/core.js
+++ b/src/fields/core.js
@@ -243,7 +243,7 @@ export class Field {
     /**
     *
     */
-    static new(id, name, schema, options = {}, parent = null) {
+    static new(id, name, schema, options = {}, parent = null, required = false, dependancies = null) {
         let fieldSpec = {
             id: id,
             name: name,
@@ -305,9 +305,9 @@ export class Field {
         if(schema.properties) {
             fieldSpec.properties = schema.properties
         }
-
+        
         // Build validator list
-        if(schema.required) {
+        if(required || (options.hasOwnProperty('required') && options.required)) {
             if(schema.type === 'boolean') {
                 validators.push(new BooleanRequiredValidator())
             } else {
@@ -315,6 +315,12 @@ export class Field {
             }
 
             fieldSpec.attribs.required = 'true'
+        }
+
+        // If the schema contains a required attribute this should be
+        // a list of required descendants - not the item itself
+        if(schema.required) {
+            fieldSpec.required = schema.required
         }
 
         if(schema.minLength) {

--- a/src/fields/object.js
+++ b/src/fields/object.js
@@ -20,7 +20,7 @@ export class ObjectField extends Field {
 
     constructor({id, name, label = null, initial = null, widget = null,
         validators = [], attribs = {}, description = null, options = {},
-        order = null, properties = {}}) {
+        order = null, properties = {}, required = []}) {
         super({
             id,
             name,
@@ -40,9 +40,15 @@ export class ObjectField extends Field {
         for(let fieldName of Object.keys(properties)) {
             let fieldId = `${name}_${fieldName}`
             let fieldOptions = {}
+            let fieldRequired = false
 
             if(this.options.hasOwnProperty(fieldName)) {
                 fieldOptions = options[fieldName]
+            }
+
+            // Check if the field is required
+            if(required && required.includes(fieldName)) {
+                fieldRequired = true
             }
 
             let field = this.constructor.new(
@@ -50,7 +56,8 @@ export class ObjectField extends Field {
                 fieldName,
                 properties[fieldName],
                 fieldOptions,
-                this // parent
+                this, // parent
+                fieldRequired
             )
 
             if(!field) {

--- a/test/unit/specs/fields/array.js
+++ b/test/unit/specs/fields/array.js
@@ -18,8 +18,8 @@ describe('ArrayField', function() {
             name: 'TestArray', 
             label: 'Test Array Field',
             items: {
-                type: "string",
-                title: "Array Item"
+                type: 'string',
+                title: 'Array Item'
             }
         })
     })    

--- a/test/unit/specs/fields/core.js
+++ b/test/unit/specs/fields/core.js
@@ -4,9 +4,10 @@
 
 'use strict'
 
-import {assert} from 'chai'
+import {assert, expect} from 'chai'
 import {Field} from '../../../../src/fields/core'
 import {TextInput, HiddenInput} from '../../../../src/widgets/text'
+import {RequiredValidator} from '../../../../src/validators/core'
 
 describe('Field', function() {
     var TestField
@@ -68,6 +69,38 @@ describe('Field', function() {
     describe('#toString()', function() {
         it('return a string representation of the field', function() {
             assert.equal('Field <TestField field>', TestField.toString())
+        })
+    })
+
+    describe('#new()', function() {
+        it('return a field with configured attributes', function() {
+            let schema = {type: 'string'}
+            let field = Field.new('test-id', 'test-name', schema)
+
+            expect(field.id).to.equal('test-id')
+            expect(field.name).to.equal('test-name')
+            expect(field.type).to.equal('string')
+            expect(field.validators.length).to.equal(0)
+        })
+
+        it('return a field as required', function() {
+            let schema = {type: 'string'}
+            let requiredField = Field.new(
+                'test-id', 'test-name', schema, {}, null, true
+            )
+
+            expect(requiredField.validators.length).to.equal(1)
+            expect(requiredField.validators[0].constructor).to.equal(RequiredValidator)
+
+            // Check the option config
+            let optionsRequiredField = Field.new(
+                'test-id', 'test-name', schema, {required: true}
+            )
+
+            expect(optionsRequiredField.validators.length).to.equal(1)
+            expect(
+                optionsRequiredField.validators[0].constructor
+            ).to.equal(RequiredValidator)
         })
     })
 })

--- a/test/unit/specs/fields/object.js
+++ b/test/unit/specs/fields/object.js
@@ -1,0 +1,43 @@
+/*
+* ObjectField Tests
+*/
+
+'use strict'
+
+import {expect} from 'chai'
+import {ObjectField} from '../../../../src/fields/object'
+import {TextField} from '../../../../src/fields/text'
+import {ObjectInput} from '../../../../src/widgets/object'
+import {RequiredValidator} from '../../../../src/validators/core'
+
+describe('ObjectField', function() {
+    var TestObjectField
+
+    beforeEach('create an ObjectField instance', function() {
+        TestObjectField = new ObjectField({
+            id: 'test-object', 
+            name: 'TestObject', 
+            label: 'Test Object Field',
+            properties: {
+                item1: {
+                    type: 'string',
+                    title: 'Item 1'
+                },
+                item2: {
+                    type: 'string',
+                    title: 'Item 2'
+                }
+            },
+            required: ['item1']
+        })
+    })    
+
+    describe('#constructor()', function() {
+        it('return field with children marked as required', function() {
+            expect(TestObjectField.object.item1.validators.length).to.equal(1)
+            expect(
+                TestObjectField.object.item1.validators[0].constructor
+            ).to.equal(RequiredValidator)
+        })
+    })
+})

--- a/test/unit/specs/widgets/date.js
+++ b/test/unit/specs/widgets/date.js
@@ -7,12 +7,13 @@
 import {expect} from 'chai'
 import jsdom from 'mocha-jsdom'
 import {Widget} from '../../../../src/widgets/core'
-import {StringField} from '../../../../src/fields/date'
+import {StringField} from '../../../../src/fields/text'
+import {DateSelectionInput} from '../../../../src/widgets/date'
 
-describe('Widget', function() {
+describe('DateSelectionInputWidget', function() {
     var TestField, TestWidget
 
-    beforeEach('create an TestWidget instance', function() {
+    beforeEach('create an DateSelectionInputWidget instance', function() {
         jsdom()
 
         TestField = new StringField({


### PR DESCRIPTION
Feat: BREAKING CHANGE support for JSON schema draft 4 format for required fields. The previous version is no longer supported and will break for no valid draft 4 schema definitions. Additional required can be controlled at a form level by using options. Resolves #7