### PR TITLE
1.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mutt-forms",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "author": {
     "name": "Nick Snell",
     "email": "nick@boughtbymany.com"

--- a/src/fields/array.js
+++ b/src/fields/array.js
@@ -42,8 +42,18 @@ export class ArrayField extends Field {
 
         // We store the array fields as slots
         this.slots = []
-        for(let i in Array.from(Array(this.minItems).keys())) { // eslint-disable-line
-            this.addSlot(false)
+        let buildPlaceholders = true
+        
+        if(this.options.hasOwnProperty('disablePlaceholders')) {
+            buildPlaceholders = !this.options.disablePlaceholders
+        }
+
+        // We may want to suppress the placeholder slots from
+        // being added by default
+        if(buildPlaceholders) {
+            for(let i in Array.from(Array(this.minItems).keys())) { // eslint-disable-line
+                this.addSlot(false)
+            }
         }
 
         this.validators.push(new LengthValidator({

--- a/test/unit/specs/fields/array.js
+++ b/test/unit/specs/fields/array.js
@@ -30,7 +30,7 @@ describe('ArrayField', function() {
     })
 
     describe('#constructor()', function() {
-        it('should return a valid set of slots', function() {
+        it('should return a valid set of slots', () => {
             let spec = {
                 type: 'array',
                 name: 'TestArray',
@@ -45,6 +45,23 @@ describe('ArrayField', function() {
             expect(TestArrayConstruct.slots.length).to.equal(1)
             expect(TestArrayConstruct.slots[0].constructor).to.equal(StringField)
             expect(TestArrayConstruct.slots[0].label).to.equal('Testing')
+        })
+
+        it('should suppress slot creation with "disablePlaceholders" option', () => {
+            let spec = {
+                type: 'array',
+                name: 'TestArray',
+                options: {
+                    disablePlaceholders: true
+                },
+                items: {
+                    type: 'string',
+                    title: 'Testing'
+                }
+            }
+
+            let TestArrayConstruct = new ArrayField(spec)
+            expect(TestArrayConstruct.slots.length).to.equal(0)
         })
     })
 


### PR DESCRIPTION
Feat: Added "disablePlaceholders" option to ArrayField to stop placeholder slots being added on initialisation. This is a solution for issues where you want to manage the slot creation yourself but not change the schema minItems